### PR TITLE
Stop using sendBeacon to report in Chrome

### DIFF
--- a/lib/reportData.js
+++ b/lib/reportData.js
@@ -9,14 +9,13 @@ var measurePerformance = require('./measurePerformance'),
     forIn = canHas.forIn,
     parse = require('./url/parse');
 
-/*
+/**
  * Safari can't use tracking pixels on unload, but xhr is said to work. Caveat is it's a sync call so it hangs the browser a split second.
  * @param {String} trackURL
  * @returns {String}
  */
 var xhrTrack = function (trackURL) {
     var xhr = new XMLHttpRequest();
-	xhr.timeout = 500;
     xhr.open('GET', trackURL, false);
     xhr.onreadystatechange = function () {
         if (xhr.readyState >= has('OPENED', xhr)) {
@@ -30,7 +29,7 @@ var xhrTrack = function (trackURL) {
     return trackURL;
 };
 
-/*
+/**
  * This method makes a call to a url but does not actually draw a pixel to a page in any way.
  * The image will be cleaned up by the browser easily because it's not referenced again past this point.
  * @param {String} trackURL
@@ -42,6 +41,14 @@ var imgTrack = function (trackURL) {
 };
 
 /**
+ * Returns true if browser is Chrome; false otherwise
+ * @returns {boolean}
+ */
+var isChrome = function () {
+    return navigator.userAgent.indexOf('Chrom') >= 0 && typeof window.chrome === 'object' && typeof window.EventSource === 'function';
+};
+
+/**
  * Returns true if browser is Safari; false otherwise
  * @returns {boolean}
  */
@@ -50,7 +57,7 @@ var isSafari = function () {
 	return uaString.indexOf('safari') > -1 && uaString.indexOf('chrom') === -1;
 };
 
-/*
+/**
  * Iterate over an object literal's properties and convert those to a string to be appended to a url
  * @param params {Object} key/value pairs to convert into a query string
  * @returns {String}
@@ -87,7 +94,8 @@ var prepareURL = function (url) {
  * @returns {Boolean}
  */
 var isSendBeaconAvailable = function () {
-    return typeof window.navigator === 'object' && typeof window.navigator.sendBeacon === 'function';
+    // Newer version of Chrome limit concurrent sendBeacon requests and abort those that pass maximum concurrency
+    return !isChrome() && typeof window.navigator === 'object' && typeof window.navigator.sendBeacon === 'function';
 };
 
 /**

--- a/test/reportData.test.js
+++ b/test/reportData.test.js
@@ -7,8 +7,13 @@ var isSafariBrowser = function () {
 	return uaString.indexOf('safari') > -1 && uaString.indexOf('chrom') === -1;
 };
 
+var isChromeBrowser = function () {
+    return navigator.userAgent.indexOf('Chrom') >= 0 && typeof window.chrome === 'object' && typeof window.EventSource === 'function';
+};
+
 var expect = require('expect.js'),
-	isSafari = isSafariBrowser();
+	isSafari = isSafariBrowser(),
+    isChrome = isChromeBrowser();
 
 /** @type {ReportData} */
 var rdSingleton = require('../lib/reportData').provider('test.reportData');
@@ -81,7 +86,7 @@ describe('reportData', function() {
 
 	// sendBeacon
     describe('sendBeacon:enabled ', function () {
-        if (!(typeof window.navigator === 'object' && (typeof window.navigator.sendBeacon === 'function'))) {
+        if (!(!isChrome && typeof window.navigator === 'object' && (typeof window.navigator.sendBeacon === 'function'))) {
             return;
         }
 


### PR DESCRIPTION
Errors occurr in Chrome when multiple sendBeacon requests are made. The reporter module no longer uses sendBeacon when it detects the browser to be Chrome and reverts to the prior way of using an image pixel.